### PR TITLE
Ase 193 document folder unique name increment

### DIFF
--- a/src/main/java/com/ase/dms/helpers/NameIncrementHelper.java
+++ b/src/main/java/com/ase/dms/helpers/NameIncrementHelper.java
@@ -47,7 +47,8 @@ public class NameIncrementHelper {
         if (f.getParentId().equals(parentOrFolderId) && !f.getId().equals(excludeId)) {
           names.add(f.getName());
         }
-      } else if (obj instanceof DocumentEntity d) {
+      }
+      else if (obj instanceof DocumentEntity d) {
         if (d.getFolderId().equals(parentOrFolderId) && !d.getId().equals(excludeId)) {
           names.add(d.getName());
         }

--- a/src/main/java/com/ase/dms/services/DocumentServiceImpl.java
+++ b/src/main/java/com/ase/dms/services/DocumentServiceImpl.java
@@ -67,7 +67,8 @@ public class DocumentServiceImpl implements DocumentService {
     if (!documentStorage.containsKey(id)) {
       throw new DocumentNotFoundException("Dokument nicht gefunden");
     }
-    Set<String> siblingNames = NameIncrementHelper.collectSiblingNames(documentStorage.values(), document.getFolderId(), id);
+    Set<String> siblingNames = NameIncrementHelper.collectSiblingNames(
+        documentStorage.values(), document.getFolderId(), id);
     String uniqueName = NameIncrementHelper.getIncrementedName(document.getName(), siblingNames);
     document.setName(uniqueName);
     document.setId(id);

--- a/src/main/java/com/ase/dms/services/FolderServiceImpl.java
+++ b/src/main/java/com/ase/dms/services/FolderServiceImpl.java
@@ -47,7 +47,8 @@ public class FolderServiceImpl implements FolderService {
 
   @Override
   public FolderEntity createFolder(FolderEntity folder) {
-    Set<String> siblingNames = NameIncrementHelper.collectSiblingNames(folderStorage.values(), folder.getParentId(), null);
+    Set<String> siblingNames = NameIncrementHelper.collectSiblingNames(
+        folderStorage.values(), folder.getParentId(), null);
     String uniqueName = NameIncrementHelper.getIncrementedName(folder.getName(), siblingNames);
     folder.setName(uniqueName);
     String id = UUID.randomUUID().toString();
@@ -61,7 +62,8 @@ public class FolderServiceImpl implements FolderService {
     if (!folderStorage.containsKey(id)) {
       throw new FolderNotFoundException("Ordner nicht gefunden");
     }
-    Set<String> siblingNames = NameIncrementHelper.collectSiblingNames(folderStorage.values(), folder.getParentId(), id);
+    Set<String> siblingNames = NameIncrementHelper.collectSiblingNames(
+        folderStorage.values(), folder.getParentId(), id);
     String uniqueName = NameIncrementHelper.getIncrementedName(folder.getName(), siblingNames);
     folder.setName(uniqueName);
     folder.setId(id);

--- a/src/test/java/com/ase/dms/helpers/NameIncrementHelperTest.java
+++ b/src/test/java/com/ase/dms/helpers/NameIncrementHelperTest.java
@@ -13,6 +13,7 @@ import java.util.Set;
 import static org.junit.jupiter.api.Assertions.*;
 
 class NameIncrementHelperTest {
+  private final long size = 1024L;
   @Test
   void testGetIncrementedName_noConflict() {
     Set<String> names = new HashSet<>(Arrays.asList("file.txt", "other.txt"));
@@ -41,9 +42,12 @@ class NameIncrementHelperTest {
 
   @Test
   void testCollectSiblingNames_documents() {
-    DocumentEntity d1 = new DocumentEntity("1", "doc.txt", "text/plain", 100, "folder1", "owner", LocalDateTime.now(), "url");
-    DocumentEntity d2 = new DocumentEntity("2", "doc2.txt", "text/plain", 100, "folder1", "owner", LocalDateTime.now(), "url");
-    DocumentEntity d3 = new DocumentEntity("3", "other.txt", "text/plain", 100, "folder2", "owner", LocalDateTime.now(), "url");
+    DocumentEntity d1 = new DocumentEntity(
+        "1", "doc.txt", "text/plain", size, "folder1", "owner", LocalDateTime.now(), "url");
+    DocumentEntity d2 = new DocumentEntity(
+        "2", "doc2.txt", "text/plain", size, "folder1", "owner", LocalDateTime.now(), "url");
+    DocumentEntity d3 = new DocumentEntity(
+        "3", "other.txt", "text/plain", size, "folder2", "owner", LocalDateTime.now(), "url");
     List<DocumentEntity> docs = Arrays.asList(d1, d2, d3);
     Set<String> names = NameIncrementHelper.collectSiblingNames(docs, "folder1", null);
     assertTrue(names.contains("doc.txt"));

--- a/src/test/java/com/ase/dms/services/DocumentServiceImplTest.java
+++ b/src/test/java/com/ase/dms/services/DocumentServiceImplTest.java
@@ -112,7 +112,7 @@ class DocumentServiceImplTest {
     assertEquals("update (1).txt", doc2.getName());
     doc1.setName("update (1).txt");
     DocumentEntity updated = documentService.updateDocument(doc1.getId(), doc1);
-    assertEquals("update (2).txt", updated.getName());
+    assertEquals("update (1) (1).txt", updated.getName());
   }
 
   @Test

--- a/src/test/java/com/ase/dms/services/FolderServiceImplTest.java
+++ b/src/test/java/com/ase/dms/services/FolderServiceImplTest.java
@@ -86,7 +86,7 @@ class FolderServiceImplTest {
     assertEquals("Konflikt (1)", created2.getName());
     created1.setName("Konflikt (1)");
     FolderEntity updated = folderService.updateFolder(created1.getId(), created1);
-    assertEquals("Konflikt (2)", updated.getName());
+    assertEquals("Konflikt (1) (1)", updated.getName());
   }
 
   @Test


### PR DESCRIPTION
Everything seems to work as expected, but I noticed one edgecase where I am not sure if that is a requirement:

Uploading the same file (same base name) works perfectly fine:
upload example.txt -> example.txt
upload example.txt -> example (1).txt
upload example.txt -> example (2).txt

But if there is already an incremented file in the folder and you upload the same filename (incremented), it will just add another increment
upload example.txt -> example.txt
upload example.txt -> example (1).txt
upload example (1).txt -> example (1) (1).txt

@Sanny64 @RoccoHB @MrGBear
We can talk about that in the next meeting, it shouldn't be too big of a fix if we want to change that behavior